### PR TITLE
reformatted history_interactions such that dt and c0 are not buried n the build_coefficient_table function. They were moved to the initialization line of the class.

### DIFF
--- a/src/interactions/history_interaction.cpp
+++ b/src/interactions/history_interaction.cpp
@@ -6,14 +6,16 @@ HistoryInteraction::HistoryInteraction(
     const std::shared_ptr<const DotVector> &dots,
     const std::shared_ptr<const History::HistoryArray> &history,
     const std::shared_ptr<GreenFunction::Dyadic> &dyadic,
-    const int interp_order)
+    const int interp_order, const double dt, const double c0)
     : Interaction(dots),
       history(history),
       dyadic(dyadic),
       interp_order(interp_order),
       num_interactions(dots->size() * (dots->size() - 1) / 2),
       floor_delays(num_interactions),
-      coefficients(boost::extents[num_interactions][interp_order + 1])
+      coefficients(boost::extents[num_interactions][interp_order + 1]),
+      dt(dt),
+      c0(c0)
 {
   build_coefficient_table();
 }
@@ -29,10 +31,10 @@ void HistoryInteraction::build_coefficient_table()
     Vec3d dr(separation((*dots)[src], (*dots)[obs]));
 
     std::pair<int, double> delay(
-        split_double(dr.norm() / (config.c0 * config.dt)));
+        split_double(dr.norm() / (c0 * dt)));
 
     floor_delays[pair_idx] = delay.first;
-    lagrange.calculate_weights(delay.second, config.dt);
+    lagrange.calculate_weights(delay.second, dt);
 
     std::vector<Eigen::Matrix3cd> interp_dyads(
         dyadic->coefficients(dr, lagrange));

--- a/src/interactions/history_interaction.h
+++ b/src/interactions/history_interaction.h
@@ -4,7 +4,6 @@
 #include <Eigen/Dense>
 #include <boost/multi_array.hpp>
 
-#include "../configuration.h"
 #include "../history.h"
 #include "../lagrange_set.h"
 #include "../quantum_dot.h"
@@ -16,7 +15,7 @@ class HistoryInteraction : public Interaction {
   HistoryInteraction(const std::shared_ptr<const DotVector> &,
                      const std::shared_ptr<const History::HistoryArray> &,
                      const std::shared_ptr<GreenFunction::Dyadic> &,
-                     const int);
+                     const int, const double, const double);
 
   virtual const ResultArray &evaluate(const int);
 
@@ -26,6 +25,8 @@ class HistoryInteraction : public Interaction {
   int interp_order, num_interactions;
   std::vector<int> floor_delays;
   boost::multi_array<cmplx, 2> coefficients;
+  const double dt;
+  const double c0;
 
   void build_coefficient_table();
 

--- a/src/interactions/pulse_interaction.h
+++ b/src/interactions/pulse_interaction.h
@@ -1,7 +1,6 @@
 #ifndef PULSE_INTERACTION_H
 #define PULSE_INTERACTION_H
 
-#include "../configuration.h"
 #include "../pulse.h"
 #include "interaction.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,8 @@ int main(int argc, char *argv[])
     std::vector<std::shared_ptr<Interaction>> interactions{
         make_shared<PulseInteraction>(qds, pulse1, config.hbar, config.dt),
         make_shared<HistoryInteraction>(qds, history, rotating_dyadic,
-                                        config.interpolation_order)};
+                                        config.interpolation_order,
+    					config.dt, config.c0)};
 
     PredictorCorrector::Integrator integrator(
         config.dt, 18, 22, 3.15, history, rhs_funs, std::move(interactions));


### PR DESCRIPTION
fixes issue #16 